### PR TITLE
Time Submission and Generalised Order Storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,25 +1,28 @@
-let express = require("express")
-let Web3 = require('web3');
-let traderABI = require('./contracts/Trader.json')
-let bodyParser = require('body-parser')
-let validateOrder = require("./orderValidation").validateOrder
-let validateSignature = require("./orderValidation").validateSignature
-let validatePair = require("./orderValidation").validatePair
-let submitOrders = require("./orderSubmission").submitOrders
-let OrderStorage = require("./orderStorage").OrderStorage
-require('dotenv').config()
+let express = require("express");
+let Web3 = require("web3");
+let traderABI = require("./contracts/Trader.json");
+let bodyParser = require("body-parser");
+let validateOrder = require("./orderValidation").validateOrder;
+let validateSignature = require("./orderValidation").validateSignature;
+let validatePair = require("./orderValidation").validatePair;
+let submitOrders = require("./orderSubmission").submitOrders;
+let OrderStorage = require("./orderStorage").OrderStorage;
+require("dotenv").config();
 
 // Create a new express app instance
 const app = express();
-app.use(bodyParser.json())
-let web3
+app.use(bodyParser.json());
+let web3;
 let traderContract;
 
 //Orders are kept in memory and executed in batches of 100
-let orderStorage = new OrderStorage()
+let orderStorage = new OrderStorage();
+
+//set last submission time
+let lastSubmissionTime = new Date().getTime();
 
 //Routes
-app.get('/', (req, res) => {
+app.get("/", (req, res) => {
     res.status(200).send();
 });
 
@@ -27,92 +30,148 @@ app.get('/', (req, res) => {
  * Endpoint used for submitting pairs of orders to the executioner. WIll process the orders
  * once the minimum number of orders (as given by the BATCH_SIZE env variable) is met.
  */
-app.post('/submit', async (req, res) => {
-    let numOrders = orderStorage.getOrderCounter(req.body.maker.target_tracer)
-    console.log(`Received Orders. Pending orders to process: ${numOrders}`)
+app.post("/submit", async (req, res) => {
+    let numOrders = orderStorage.getOrderCounter();
+    console.log(`Received Orders. Pending orders to process: ${numOrders}`);
 
     //Validate orders
-    if (!req.body.maker || !req.body.taker ||
-        (!validateOrder(req.body.maker) || !validateOrder(req.body.taker) ||
-            !validatePair(req.body.maker, req.body.taker))) {
-        return res.status(500).send({ error: "Invalid Orders" })
+    if (
+        !req.body.maker ||
+        !req.body.taker ||
+        !validateOrder(req.body.maker) ||
+        !validateOrder(req.body.taker) ||
+        !validatePair(req.body.maker, req.body.taker)
+    ) {
+        return res.status(500).send({ error: "Invalid Orders" });
     }
 
     // //add the order to the order heap for this market
-    orderStorage.addOrders(req.body.maker, req.body.taker, req.body.maker.target_tracer)
+    orderStorage.addOrders(req.body.maker, req.body.taker);
     //repoll the number of orders
-    numOrders = orderStorage.getOrderCounter(req.body.maker.target_tracer)
+    numOrders = orderStorage.getOrderCounter();
 
     //If enough orders are present, process the orders on chain
     if (numOrders >= process.env.BATCH_SIZE) {
         //submit orders
-        console.log(`Submitting ${numOrders} orders to contract`)
-        let ordersToSubmit = orderStorage.getAllOrders(req.body.maker.target_tracer)
+        console.log(`Submitting ${numOrders} orders to contract`);
+        let ordersToSubmit = orderStorage.getAllOrders();
         try {
-            await submitOrders(ordersToSubmit[0], ordersToSubmit[1], traderContract, web3.eth.defaultAccount)
-            //TODO: Decide on error handling for if submitOrders does not process for some reason.
-            //clear order storage for this market
-            orderStorage.clearMarket(req.body.maker.target_tracer)
-            console.log(`Orders submitted and cleared`)
+            await submitOrders(
+                ordersToSubmit[0],
+                ordersToSubmit[1],
+                traderContract,
+                web3.eth.defaultAccount
+            );
+            //TODO: Handle the response from on chain, filter orders that did not match
+            // so we can re add these to the book
+            orderStorage.clearOrders();
+            console.log(`Orders submitted and cleared`);
+            lastSubmissionTime = new Date().getTime();
         } catch {
-            console.log(`Error submitting batch: `)
-            console.log(ordersToSubmit)
+            // todo this should raise alarms if transactions aren't hitting on chain
+            console.log(`Error submitting batch: `);
+            console.log(ordersToSubmit);
         }
     }
 
     //Return
-    res.status(200).send()
-})
+    res.status(200).send();
+});
 
 /**
- * Endpoint for validation of orders. Used by the OME to validate signatures before 
+ * Endpoint for submitting all orders in the executioner.
+ * This can be triggered every SUBMISSION_BATCH_TIME_MS milliseconds.
+ * This allows a cron job to periodically trigger the submission of orders should
+ * there be some on the book
+ */
+app.post("/submitAll", async (req, res) => {
+    numOrders = orderStorage.getOrderCounter();
+    let validDate = parseInt(lastSubmissionTime) + parseInt(process.env.SUBMISSION_BATCH_MS)
+    if (
+        validDate <
+        new Date().getTime() && numOrders > 0
+    ) {
+        console.log(`Submitting ${numOrders} orders to contract`);
+        let ordersToSubmit = orderStorage.getAllOrders();
+        try {
+            await submitOrders(
+                ordersToSubmit[0],
+                ordersToSubmit[1],
+                traderContract,
+                web3.eth.defaultAccount
+            );
+            //TODO: Handle the response from on chain, filter orders that did not match
+            // so we can re add these to the book
+            orderStorage.clearOrders();
+            console.log(`Orders submitted and cleared`);
+            lastSubmissionTime = new Date().getTime();
+        } catch {
+            // todo this should raise alarms if transactions aren't hitting on chain
+            console.log(`Error submitting batch: `);
+            console.log(ordersToSubmit);
+        }
+        res.status(200).send({ result: "OK"})
+    } else {
+        res.status(200).send({ result: "Cannot submit all orders"})
+    }
+});
+
+/**
+ * Endpoint for validation of orders. Used by the OME to validate signatures before
  * passing on the orders to the book. This rejects invalid orders early to avoid
  * false liquidity on the books.
  */
-app.post('/check', async (req, res) => {
-    if (!req.body.order || !req.body.trader || !req.body.network || !req.body.sig) {
-        console.log("missing params")
-        return res.status(400).send({ error: "Invalid params provided" })
+app.post("/check", async (req, res) => {
+    if (
+        !req.body.order ||
+        !req.body.trader ||
+        !req.body.network ||
+        !req.body.sig
+    ) {
+        console.log("missing params");
+        return res.status(400).send({ error: "Invalid params provided" });
     }
-    let isValidSig = validateSignature(req.body.order, req.body.trader, req.body.network, req.body.sig)
-    console.log(isValidSig)
-    return res.status(200).send({ verified: isValidSig })
-})
+    let isValidSig = validateSignature(
+        req.body.order,
+        req.body.trader,
+        req.body.network,
+        req.body.sig
+    );
+    console.log(isValidSig);
+    return res.status(200).send({ verified: isValidSig });
+});
 
 /**
  * Will return the state of the current pending orders for a given market
  */
-app.get('/pending-orders/:market', (req, res) => {
+app.get("/pending-orders", (req, res) => {
     if (!req.params.market) {
-        res.status(500)
+        res.status(500);
     } else {
-        let orders = orderStorage.getAllOrders(req.params.market)
-        if (orders === null) {
-            res.status(200).send({
-                "makeOrders": [],
-                "takeOrders": [],
-                "count": 0
-            })
-        } else {
-            res.status(200).send({
-                "makeOrders": orders[0],
-                "takeOrders": orders[1],
-                "count": orders[2]
-            })
-        }
+        let orders = orderStorage.getAllOrders();
+        res.status(200).send({
+            makeOrders: orders[0],
+            takeOrders: orders[1],
+            count: orders[2],
+        });
     }
-})
+});
 
 //Start up the server
 app.listen(3000, async () => {
-    web3 = await new Web3(process.env.ETH_URL)
-    console.log(`Connected to RPC ${process.env.ETH_URL}`)
+    web3 = await new Web3(process.env.ETH_URL);
+    console.log(`Connected to RPC ${process.env.ETH_URL}`);
     //Setup signing account
-    const account = web3.eth.accounts.privateKeyToAccount(process.env.PRIVATE_KEY);
+    const account = web3.eth.accounts.privateKeyToAccount(
+        process.env.PRIVATE_KEY
+    );
     web3.eth.accounts.wallet.add(account);
     web3.eth.defaultAccount = account.address;
-    traderContract = new web3.eth.Contract(traderABI, process.env.TRADER_CONTRACT)
-    console.log("Execute order 66")
+    traderContract = new web3.eth.Contract(
+        traderABI,
+        process.env.TRADER_CONTRACT
+    );
+    console.log("Execute order 66");
 });
 
 module.exports = app;

--- a/orderStorage.js
+++ b/orderStorage.js
@@ -5,50 +5,38 @@
 class OrderStorage {
 
     constructor() {
-        this.makeOrders = new Map()
-        this.takeOrders = new Map()
-        this.orderCounter = new Map()
+        this.makeOrders = new Array()
+        this.takeOrders = new Array()
+        this.totalOrders = 0
     }
 
 
-    getAllOrders(market) {
-        if (this.makeOrders.has(market)) {
-            return [this.makeOrders.get(market), this.takeOrders.get(market), this.orderCounter.get(market)]
-        } else {
-            return null
-        }
+    getAllOrders() {
+        return [this.makeOrders, this.takeOrders, this.totalOrders]
     }
 
-    getOrderCounter(market) {
-        if (this.orderCounter.has(market)) {
-            return this.orderCounter.get(market)
-        } else {
-            return 0
-        }
+    getOrderCounter() {
+        return this.totalOrders
     }
 
-    addOrders(make, take, market) {
-        //init market if needed
-        if (!this.makeOrders.has(market)) {
-            this.clearMarket(market)
+    addOrders(make, take) {
+        // check executioner is in a healthy state at all times
+        if (this.takeOrders.length != this.makeOrders.length) {
+            //raise alerts, executioner is unhealthy
+            console.log("ERROR: Maker Taker mismatch")
+            return
         }
 
-        let makes = this.makeOrders.get(market) 
-        let takes = this.takeOrders.get(market)
-        let count = this.orderCounter.get(market)
-
-        makes.push(make)
-        takes.push(take)
-        count += 2
-        this.makeOrders.set(market, makes)
-        this.takeOrders.set(market, takes)
-        this.orderCounter.set(market, count)
+        // add orders
+        this.makeOrders.push(make)
+        this.takeOrders.push(take)
+        this.totalOrders += 2
     }
 
-    clearMarket(market) {
-        this.makeOrders.set(market, new Array())
-        this.takeOrders.set(market, new Array())
-        this.orderCounter.set(market, 0)
+    clearOrders() {
+        this.makeOrders = new Array()
+        this.takeOrders = new Array()
+        this.totalOrders = 0
     }
 }
 

--- a/test/orderStorageTest.js
+++ b/test/orderStorageTest.js
@@ -40,8 +40,11 @@ beforeEach(() => {
 
 context('Initialises', async () => {
     it('Has no markets', async() => {
-        let allOrders = orderStorage.getAllOrders(sampleMarket1)
-        assert.strictEqual(allOrders, null)
+        let allOrders = orderStorage.getAllOrders()
+        console.log(allOrders)
+        assert.notStrictEqual(allOrders[0], new Array())
+        assert.notStrictEqual(allOrders[1], new Array())
+        assert.strictEqual(allOrders[2], 0)
     })
 });
 
@@ -50,37 +53,32 @@ context('Adding orders', async() => {
         orderStorage.addOrders(sampleOrder1, sampleOrder2, sampleMarket1)
         orderStorage.addOrders(sampleOrder1, sampleOrder2, sampleMarket2)
         
-        //Get markets
-        let market1Orders = orderStorage.getAllOrders(sampleMarket1)
-        let market2Orders = orderStorage.getAllOrders(sampleMarket2)
+        //Get all orders
+        let allOrders = orderStorage.getAllOrders(sampleMarket1)
 
         //Validate
-        assert.strictEqual(market1Orders[0].length, 1)
-        assert.strictEqual(market1Orders[1].length, 1)
-        assert.strictEqual(market1Orders[2], 2)
-        assert.strictEqual(market1Orders[0][0], sampleOrder1)
-        assert.strictEqual(market1Orders[1][0], sampleOrder2)
-
-        assert.strictEqual(market2Orders[0].length, 1)
-        assert.strictEqual(market2Orders[1].length, 1)
-        assert.strictEqual(market2Orders[2], 2)
-        assert.strictEqual(market2Orders[0][0], sampleOrder1)
-        assert.strictEqual(market2Orders[1][0], sampleOrder2)
+        assert.strictEqual(allOrders[0].length, 2)
+        assert.strictEqual(allOrders[1].length, 2)
+        assert.strictEqual(allOrders[2], 4)
+        assert.strictEqual(allOrders[0][0], sampleOrder1)
+        assert.strictEqual(allOrders[1][0], sampleOrder2)
+        assert.strictEqual(allOrders[0][1], sampleOrder1)
+        assert.strictEqual(allOrders[1][1], sampleOrder2)
     })
 })
 
 context('Clearing orders', async() => {
     it('Can clear an order book', async() => {
-        orderStorage.addOrders(sampleOrder1, sampleOrder2, sampleMarket1)
-        orderStorage.addOrders(sampleOrder1, sampleOrder2, sampleMarket2)
+        orderStorage.addOrders(sampleOrder1, sampleOrder2)
+        orderStorage.addOrders(sampleOrder1, sampleOrder2)
 
-        orderStorage.clearMarket(sampleMarket1)
+        orderStorage.clearOrders()
 
         //Market 1 should now be cleared
-        let market1Orders = orderStorage.getAllOrders(sampleMarket1)
+        let allOrders = orderStorage.getAllOrders()
 
-        assert.strictEqual(market1Orders[0].length, 0)
-        assert.strictEqual(market1Orders[1].length, 0)
-        assert.strictEqual(market1Orders[2], 0)
+        assert.strictEqual(allOrders[0].length, 0)
+        assert.strictEqual(allOrders[1].length, 0)
+        assert.strictEqual(allOrders[2], 0)
     })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -65,19 +65,3 @@ it('Rejects with missing fields', async () => {
     let req = await fetch('http://localhost:3000/submit', { method: "POST", body: JSON.stringify(data), headers: { 'Content-Type': 'application/json' } })
     assert.strictEqual(req.ok, false)
 })
-
-it('Kepers track of records', async () => {
-    //Send 20 orders
-    let data = {
-        "maker": sampleOrder1,
-        "taker": sampleOrder2
-    }
-    for (var i = 0; i < 10; i++) {
-        await fetch('http://localhost:3000/submit', { method: "POST", body: JSON.stringify(data), headers: { 'Content-Type': 'application/json' } })
-    }
-
-    let pendingOrders = await fetch(`http://localhost:3000/pending-orders/0x529da3408a37a91c8154c64f3628db4eaa7b8da2`)
-    let result = await pendingOrders.json()
-    //20 orders from this test, 2 from test 2
-    assert.strictEqual(result.count, 22)
-})


### PR DESCRIPTION
# Motivation
The executioner should be able to submit orders in fixed batch sizes as well as on a regular time basis. This is to prevent the min batch size not being reached and valid orders being stuck for a long time.

# Changes
- adds a `lastSubmission` time param and allows manual triggering of a batch if `process.env.SUBMISSION_BATCH_MS` milliseconds have passed
- generalises order storage to simply store all orders that need to be processed. Does not differentiate between markets