### PR TITLE
[validation] validate timestamps as seconds not milliseconds

### DIFF
--- a/orderValidation.js
+++ b/orderValidation.js
@@ -94,7 +94,7 @@ const validateCreatedTime = (created) => {
   return (
     created != null &&
     !isNaN(created) &&
-    Number(created) <= Date.now()
+    Number(created) <= parseInt(Date.now() / 1000)
   )
 }
 
@@ -105,7 +105,7 @@ const validateExpiryTime = (expiry) => {
   return (
     expiry != null &&
     !isNaN(expiry) &&
-    Number(expiry) >= Date.now()
+    Number(expiry) >= parseInt(Date.now() / 1000)
   )
 }
 

--- a/test/orderValidation.js
+++ b/test/orderValidation.js
@@ -84,11 +84,11 @@ context('Validating Created Time', () => {
     })
 
     it('Is invalid if in the future', () => {
-      assert.strictEqual(false, validateCreatedTime(Date.now() + 100))
+      assert.strictEqual(false, validateCreatedTime(parseInt(Date.now() / 1000) + 100))
     })
 
     it('Is valid if a number now or in the past', () => {
-      assert.strictEqual(true, validateCreatedTime(Date.now()))
+      assert.strictEqual(true, validateCreatedTime(parseInt(Date.now() / 1000)))
     })
 })
 
@@ -102,11 +102,11 @@ context('Validating Expiry Time', () => {
   })
 
   it('Is invalid if in the past', () => {
-    assert.strictEqual(false, validateExpiryTime(Date.now() - 100))
+    assert.strictEqual(false, validateExpiryTime(parseInt(Date.now() / 1000) - 100))
   })
 
   it('Is valid if in the future', () => {
-    assert.strictEqual(true, validateExpiryTime(Date.now() + 100))
+    assert.strictEqual(true, validateExpiryTime(parseInt(Date.now() / 1000) + 100))
   })
 })
 


### PR DESCRIPTION
# Motivation
- Since orders are stored on-chain with timestamps in seconds, the validation needs to be consistent with that

# Changes
- Update order validation to assume timestamps are in seconds instead of milliseconds
- Update test cases to suit